### PR TITLE
Fix integration test script jar path

### DIFF
--- a/pipeline/s1-create-skeleton/ITMavenHelloWorldProject/scripts/run-integration-tests.sh
+++ b/pipeline/s1-create-skeleton/ITMavenHelloWorldProject/scripts/run-integration-tests.sh
@@ -1,7 +1,22 @@
 #!/bin/sh
 
-cp ../../MavenHelloWorldProject/target/MavenHelloWorldProject-1.0-SNAPSHOT.jar ../target/
+# Determine the directory where this script resides so that it can be executed
+# from any location. The project root is the parent directory of this script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-java -jar ./../target/ITMavenHelloWorldProject-1.0-SNAPSHOT.jar
+# Ensure the target directory exists
+mkdir -p "$PROJECT_ROOT/target"
+
+# Copy the built application JAR from the main Maven project. This JAR is needed
+# for the integration tests to run correctly.
+cp "$PROJECT_ROOT/../MavenHelloWorldProject/target/MavenHelloWorldProject-1.0-SNAPSHOT.jar" \
+   "$PROJECT_ROOT/target/"
+
+# Execute the integration test JAR produced by this project. The assembly plugin
+# creates a JAR with all dependencies bundled, suffixed with
+# '-jar-with-dependencies'.
+java -jar "$PROJECT_ROOT/target/ITMavenHelloWorldProject-1.0-SNAPSHOT-jar-with-dependencies.jar"
+
 
 


### PR DESCRIPTION
## Summary
- fix incorrect jar path for integration test runner

## Testing
- `shellcheck pipeline/s1-create-skeleton/ITMavenHelloWorldProject/scripts/run-integration-tests.sh`
- `bash -n pipeline/s1-create-skeleton/ITMavenHelloWorldProject/scripts/run-integration-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841a57293808320a3fa376ced917a1c